### PR TITLE
fix(header): update news link to redirect to home

### DIFF
--- a/frontend/components/shared/Header.vue
+++ b/frontend/components/shared/Header.vue
@@ -54,7 +54,7 @@ const navLinks: Array<LINK_TYPE> = [
    {
       id: 2,
       name: CurrentRoute['news'],
-      link: '/News'
+      link: '/'
    }
 ];
 </script>


### PR DESCRIPTION
Changes the link for the news navigation item from '/News' to '/' 
to ensure users are directed to the home page instead of a 
specific news section. This improves user experience by 
providing a more intuitive navigation flow.